### PR TITLE
Hotglue singer sdk upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-hotglue-singer-sdk = "1.0.1"
+hotglue-singer-sdk = "1.0.7"
 hotglue-etl-exceptions = "0.1.0"
 unidecode = "^1.3.8"
 beautifulsoup4 = "^4.13.4"


### PR DESCRIPTION
Upgrade `hotglue-singer-sdk` dependency to version `1.0.7`.

---
<a href="https://cursor.com/background-agent?bcId=bc-608ab98e-d0ac-4699-b05c-c4fc4e167a83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-608ab98e-d0ac-4699-b05c-c4fc4e167a83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

